### PR TITLE
Fixed issue with hermes and prototype.toString

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,7 @@ export function toMilliseconds(
 
     // Is it a valid Date object?
     // $FlowFixMe: Cannot get `Object.prototype.toString` because property `toString` [1] cannot be unbound from the context [2] where it was defined.
-    if (Object.prototype.toString.call(value) === '[object Date]') {
+    if (value instanceof Date) {
       options[key] = value.getTime();
     }
   });


### PR DESCRIPTION
I was running into issues when rendering the datetimepicker on Android in release mode only (dev worked fine).
Opening the Picker crashed my app (stacktrace attached).

Looking through the trace, i narrowed it down to an issue with the line `if (Object.prototype.toString.call(value) === '[object Date]') {` in `toMilliseconds` in `utils.js`.

Wondering why this might be an issue and knowing that "release mode only" bugs are often related to hermes, I found that using `Function.prototype.toString` is not supported when using hermes (Source: https://hermesengine.dev/docs/language-features/#miscellaneous-incompatibilities).

I therefore changed the way dates are detected. It works for me now.

```c
09-20 15:22:20.248  8181  8236 E ReactNativeJS: TypeError: Object is not a function, js engine: hermes
09-20 15:22:20.265  8181  8237 E AndroidRuntime: FATAL EXCEPTION: mqt_native_modules
09-20 15:22:20.265  8181  8237 E AndroidRuntime: Process: my.app.opsec, PID: 8181
09-20 15:22:20.265  8181  8237 E AndroidRuntime: com.facebook.react.common.JavascriptException: TypeError: Object is not a function, js engine: hermes, stack:
09-20 15:22:20.265  8181  8237 E AndroidRuntime: toString@1:761211
09-20 15:22:20.265  8181  8237 E AndroidRuntime: anonymous@1:757790
09-20 15:22:20.265  8181  8237 E AndroidRuntime: anonymous@1:761297
09-20 15:22:20.265  8181  8237 E AndroidRuntime: loadModuleImplementation@1:37666
09-20 15:22:20.265  8181  8237 E AndroidRuntime: guardedLoadModule@1:37172
09-20 15:22:20.265  8181  8237 E AndroidRuntime: metroRequire@1:36843
09-20 15:22:20.265  8181  8237 E AndroidRuntime: toString@1:761203
09-20 15:22:20.265  8181  8237 E AndroidRuntime: each@1:901982
09-20 15:22:20.265  8181  8237 E AndroidRuntime: toMilliseconds@1:901938
09-20 15:22:20.265  8181  8237 E AndroidRuntime: ?anon_0_@1:901455
09-20 15:22:20.265  8181  8237 E AndroidRuntime: asyncGeneratorStep@1:564346
09-20 15:22:20.265  8181  8237 E AndroidRuntime: _next@1:564616
09-20 15:22:20.265  8181  8237 E AndroidRuntime: anonymous@1:564568
09-20 15:22:20.265  8181  8237 E AndroidRuntime: tryCallTwo@61:8
09-20 15:22:20.265  8181  8237 E AndroidRuntime: doResolve@216:24
09-20 15:22:20.265  8181  8237 E AndroidRuntime: Promise@82:13
09-20 15:22:20.265  8181  8237 E AndroidRuntime: anonymous@1:564489
09-20 15:22:20.265  8181  8237 E AndroidRuntime: open@1:901380
09-20 15:22:20.265  8181  8237 E AndroidRuntime: anonymous@1:903830
09-20 15:22:20.265  8181  8237 E AndroidRuntime: ?anon_0_@1:900212
09-20 15:22:20.265  8181  8237 E AndroidRuntime: asyncGeneratorStep@1:564346
09-20 15:22:20.265  8181  8237 E AndroidRuntime: _next@1:564616
09-20 15:22:20.265  8181  8237 E AndroidRuntime: anonymous@1:564568
09-20 15:22:20.265  8181  8237 E AndroidRuntime: tryCallTwo@61:8
09-20 15:22:20.265  8181  8237 E AndroidRuntime: doResolve@216:24
09-20 15:22:20.265  8181  8237 E AndroidRuntime: Promise@82:13
09-20 15:22:20.265  8181  8237 E AndroidRuntime: anonymous@1:564489
09-20 15:22:20.265  8181  8237 E AndroidRuntime: presentPicker@1:900697
09-20 15:22:20.265  8181  8237 E AndroidRuntime: open@1:899675
09-20 15:22:20.265  8181  8237 E AndroidRuntime: showOrUpdatePicker@1:905348
09-20 15:22:20.265  8181  8237 E AndroidRuntime: commitHookEffectListMount@1:296884
09-20 15:22:20.265  8181  8237 E AndroidRuntime: flushPassiveEffects@1:310457
09-20 15:22:20.265  8181  8237 E AndroidRuntime: anonymous@1:309580
09-20 15:22:20.265  8181  8237 E AndroidRuntime: J@1:251141
09-20 15:22:20.265  8181  8237 E AndroidRuntime: R@1:251472
09-20 15:22:20.265  8181  8237 E AndroidRuntime: anonymous@1:154377
09-20 15:22:20.265  8181  8237 E AndroidRuntime: _callTimer@1:153326
09-20 15:22:20.265  8181  8237 E AndroidRuntime: _callReactNativeMicrotasksPass@1:153490
09-20 15:22:20.265  8181  8237 E AndroidRuntime: callReactNativeMicrotasks@1:155457
09-20 15:22:20.265  8181  8237 E AndroidRuntime: __callReactNativeMicrotasks@1:57794
09-20 15:22:20.265  8181  8237 E AndroidRuntime: anonymous@1:56887
09-20 15:22:20.265  8181  8237 E AndroidRuntime: __guard@1:57635
09-20 15:22:20.265  8181  8237 E AndroidRuntime: flushedQueue@1:56798
09-20 15:22:20.265  8181  8237 E AndroidRuntime: callFunctionReturnFlushedQueue@1:56654
09-20 15:22:20.265  8181  8237 E AndroidRuntime:
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at com.facebook.react.modules.core.ExceptionsManagerModule.reportException(ExceptionsManagerModule.java:72)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:188)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at com.facebook.jni.NativeRunnable.run(Native Method)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:942)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:201)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:288)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:228)
09-20 15:22:20.265  8181  8237 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:1012)
```